### PR TITLE
Docs/commit signing guide

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -45,7 +45,12 @@
     "pomodoro",
     "headspace",
     "styleguide",
-    "msys"
+    "msys",
+    "keysize",
+    "keyid",
+    "signingkey",
+    "clearsign",
+    "gpgconf"
   ],
   "ignorePaths": ["node_modules", "coverage", "dist", ".git", ".husky/_", "package-lock.json"],
   "enableFiletypes": ["js", "jsx", "ts", "tsx", "json", "md", "css", "html"],

--- a/docs/COMMIT_SIGNING_GUIDE.md
+++ b/docs/COMMIT_SIGNING_GUIDE.md
@@ -1,70 +1,14 @@
-# Commit Message and Signing Guide
-
-To maintain a clean and readable git history, this project enforces certain conventions for commit messages and requires all commits to be signed.
-
----
-
-## Commit Message Guidelines
-
-We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. This creates an explicit commit history, which makes it easier to track features, fixes, and changes.
-
-### Format
-
-Each commit message consists of a **header** and an optional **body**.
-
-```
-<type>: <description>
-
-[optional body]
-```
-
-### Type
-
-The `<type>` must be one of the following:
-
-- **build**: Changes to the build system, tooling, or dependencies.
-- **chore**: Routine tasks, maintenance, or auxiliary tool changes.
-- **docs**: Documentation only changes.
-- **feat**: A new feature for the user.
-- **fix**: A bug fix for the user.
-- **refactor**: A code change that neither fixes a bug nor adds a feature.
-
-### Examples
-
-```
-feat: add workspace validation
-
-This commit introduces validation for workspace configuration files.
-It checks layout structure, command syntax, and environment variables.
-```
-
-```
-build: add git hooks for code quality enforcement
-
-Adds pre-commit, commit-msg, and pre-push hooks to enforce code
-standards before commits reach the repository.
-```
-
-```
-docs: update developer setup guide
-
-Adds instructions for installing development tools and configuring
-the local environment.
-```
-
----
-
-## Commit Signing (GPG Setup)
+# Commit Signing Guide
 
 This repository requires all commits to be cryptographically signed to ensure authenticity. Here is a guide to setting up your GPG key.
 
-### 1. Install GPG
+## 1. Install GPG
 
 - **macOS:** Install via [Homebrew](https://brew.sh/): `brew install gpg`
 - **Windows:** Install via [Gpg4win](https://www.gpg4win.org/).
 - **Linux:** Install via your package manager: `sudo apt-get install gnupg`
 
-### 2. Generate Your GPG Key
+## 2. Generate Your GPG Key
 
 Run the following command and follow the prompts. For a detailed walkthrough, see GitHub's guide on [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key).
 
@@ -78,7 +22,7 @@ gpg --full-generate-key
 - Keysize: Use 4096 bits for strong security.
 - Email address: This must match the email you use for your GitHub account.
 
-### 3. Add Your GPG Key to GitHub
+## 3. Add Your GPG Key to GitHub
 
 1. **List your keys** to find your GPG key ID:
 
@@ -96,7 +40,7 @@ gpg --full-generate-key
 
 3. **Add to GitHub**: Copy the entire output and paste it as a new GPG key in your GitHub settings. For step-by-step instructions, see GitHub's guide on [Adding a GPG key to your GitHub account](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
 
-### 4. Configure Git
+## 4. Configure Git
 
 Tell Git to use your key and sign all commits automatically. For more details, see GitHub's guide on [Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
 
@@ -106,7 +50,7 @@ git config --global user.signingkey YOUR_KEY_ID
 git config --global commit.gpgsign true
 ```
 
-### 5. Verify Your Setup
+## 5. Verify Your Setup
 
 Test that signing is working without adding unnecessary commits to your history:
 
@@ -161,7 +105,9 @@ git rebase --continue
 - **Team coordination**: Inform team members as they'll need to reset their local branches
 - **Backup first**: Create a backup branch before rewriting history: `git branch backup-branch`
 
-### Troubleshooting Signing Issues
+---
+
+## Troubleshooting
 
 **GPG Agent Not Running:**
 

--- a/docs/COMMIT_SIGNING_GUIDE.md
+++ b/docs/COMMIT_SIGNING_GUIDE.md
@@ -1,286 +1,192 @@
-# Commit Signing Guide
+# Commit Message and Signing Guide
 
-## Why Sign Your Commits?
-
-### What is Commit Signing?
-
-Commit signing is a process that cryptographically verifies that a commit was made by an authorized contributor. This ensures that code changes in your repository come from legitimate sources.
-
-### Why is Commit Signing Important?
-
-- **Authenticity**: Prevents impersonation by ensuring commits come from verified contributors.
-- **Security**: Protects against supply chain attacks where malicious actors insert unauthorized code.
-- **Trust**: Builds confidence among team members and project maintainers.
-- **Compliance**: Required for some organizations and open-source projects following security best practices.
-
-### Advantages of Signed Commits
-
-- Ensures authorship integrity
-- Helps prevent unauthorized code injection
-- Required by some security-conscious projects
-- Useful in compliance-driven workflows
-
-> **Note**: This project supports both GPG and Gitsign for commit signing. Choose the method that works best for your workflow.
+To maintain a clean and readable git history, this project enforces certain conventions for commit messages and requires all commits to be signed.
 
 ---
 
-## How to Set Up Commit Signing with Sigstore (gitsign)
+## Commit Message Guidelines
 
-We will use **Sigstore's gitsign** for keyless commit signing. This method does not require managing long-term keys and ensures that all commits in all repositories are automatically signed.
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. This creates an explicit commit history, which makes it easier to track features, fixes, and changes.
 
-### Gitsign Installation Guide
+### Format
 
-Gitsign does not have a single universal installation command for all systems. The recommended installation approach is to download the appropriate binary or package from the official [Gitsign Releases](https://github.com/sigstore/gitsign/releases) page.
+Each commit message consists of a **header** and an optional **body**.
 
-### Identifying Your System
+```
+<type>: <description>
 
-Before installation, identify your **Operating System** and **System Architecture**.
-
-#### Linux and macOS
-
-Use the following command to determine your architecture:
-
-```sh
-uname -sm
+[optional body]
 ```
 
-Expected results:
+### Type
 
-- `Linux x86_64` → `linux_amd64`
-- `Linux aarch64` → `linux_arm64`
-- `Darwin x86_64` → `darwin_amd64`
-- `Darwin arm64` (Apple Silicon) → `darwin_arm64`
+The `<type>` must be one of the following:
 
-To verify on macOS with more detail:
+- **build**: Changes to the build system, tooling, or dependencies.
+- **chore**: Routine tasks, maintenance, or auxiliary tool changes.
+- **docs**: Documentation only changes.
+- **feat**: A new feature for the user.
+- **fix**: A bug fix for the user.
+- **refactor**: A code change that neither fixes a bug nor adds a feature.
 
-```sh
-uname -m
-# or
-arch
+### Examples
+
+```
+feat: add workspace validation
+
+This commit introduces validation for workspace configuration files.
+It checks layout structure, command syntax, and environment variables.
 ```
 
-If the result is `arm64`, you're on an Apple Silicon Mac. If it's `x86_64`, you're on an Intel Mac.
+```
+build: add git hooks for code quality enforcement
 
-#### Windows
-
-To determine architecture on Windows:
-
-##### Using PowerShell:
-
-```powershell
-echo $env:PROCESSOR_ARCHITECTURE
+Adds pre-commit, commit-msg, and pre-push hooks to enforce code
+standards before commits reach the repository.
 ```
 
-Possible outputs:
-
-- `AMD64` → 64-bit (x86_64)
-- `ARM64` → ARM-based systems
-- `x86` → 32-bit (not recommended for Gitsign)
-
-##### Using Command Prompt:
-
-```cmd
-wmic os get osarchitecture
 ```
+docs: update developer setup guide
 
-### Windows Installation
-
-Download the appropriate `.exe` file based on your architecture.
-
-#### Command Prompt:
-
-```cmd
-curl -LO https://github.com/sigstore/gitsign/releases/latest/download/gitsign_<VERSION>_windows_amd64.exe
+Adds instructions for installing development tools and configuring
+the local environment.
 ```
-
-#### PowerShell:
-
-```powershell
-Invoke-WebRequest -Uri "https://github.com/sigstore/gitsign/releases/latest/download/gitsign_<VERSION>_windows_amd64.exe" -OutFile "gitsign.exe"
-```
-
-Move `gitsign.exe` to a directory that is part of your system `PATH`, allowing you to run it from any terminal.
-
-#### Common folder options:
-
-- `C:\Program Files\Gitsign\` (create this directory manually)
-- `C:\Windows\System32\` (requires admin rights)
-
-#### To add Gitsign to your PATH:
-
-1. Press `Win + S` and search for **Environment Variables**, then select **Edit the system environment variables**.
-2. In the **System Properties** window, click the **Environment Variables** button.
-3. Under **System variables**, scroll and select the `Path` variable. Click **Edit**.
-4. In the new window, click **New** and enter the full path where `gitsign.exe` is located, such as `C:\Program Files\Gitsign`.
-5. Click **OK** on all dialogs to save.
-6. Restart any open terminal windows (Command Prompt or PowerShell).
-
-You can now run `gitsign` from any terminal window globally.
-
-### Linux Installation
-
-Download the correct installer based on your package manager:
-
-```sh
-# Debian-based
-sudo dpkg -i gitsign_<VERSION>_linux_amd64.deb
-
-# RHEL-based
-sudo rpm -i gitsign_<VERSION>_linux_amd64.rpm
-
-# Alpine Linux
-sudo apk add --allow-untrusted gitsign_<VERSION>_linux_amd64.apk
-```
-
-#### Or run the binary directly:
-
-```sh
-curl -LO https://github.com/sigstore/gitsign/releases/latest/download/gitsign_<VERSION>_linux_amd64
-chmod +x gitsign_<VERSION>_linux_amd64
-sudo mv gitsign_<VERSION>_linux_amd64 /usr/local/bin/gitsign
-```
-
-### macOS Installation
-
-#### Option 1: Homebrew (Recommended if available)
-
-```sh
-brew install gitsign
-```
-
-If the tap or package isn't available, add the custom tap first:
-
-```sh
-brew tap sigstore/tap
-brew install gitsign
-```
-
-If installation still fails, use manual installation.
-
-#### Option 2: Manual Installation
-
-```sh
-curl -LO https://github.com/sigstore/gitsign/releases/latest/download/gitsign_<VERSION>_darwin_arm64
-chmod +x gitsign_<VERSION>_darwin_arm64
-sudo mv gitsign_<VERSION>_darwin_arm64 /usr/local/bin/gitsign
-```
-
-Replace `darwin_arm64` with `darwin_amd64` for Intel Macs.
-
-### Configuring Commit Signing with Gitsign
-
-### Verifying Gitsign Installation
-
-After installing Gitsign, you can verify the installation by running:
-
-```sh
-gitsign --version
-```
-
-You should see the installed version number printed in the terminal. If this command does not work, ensure that `gitsign` is properly added to your system `PATH`.
-
-After installation, configure Git to use Gitsign:
-
-```sh
-git config --global commit.gpgsign true  # Sign all commits
-git config --global tag.gpgsign true     # Sign all tags
-git config --global gpg.x509.program gitsign  # Use Gitsign for signing
-git config --global gpg.format x509      # Gitsign expects x509 args
-```
-
-### Notes
-
-- This version placeholder (`<VERSION>`) applies to all installation commands in the Gitsign Installation Guide section under **How to Set Up Commit Signing with Sigstore (gitsign)**. Replace it with the appropriate release version (e.g., `v0.12.0`) or use the `latest` keyword in download URLs.
-- Always refer to the [Gitsign Releases](https://github.com/sigstore/gitsign/releases) page for updated versions and checksums.
 
 ---
 
-## Verifying Signed Commits
+## Commit Signing (GPG Setup)
 
-To verify commit signatures:
+This repository requires all commits to be cryptographically signed to ensure authenticity. Here is a guide to setting up your GPG key.
 
-```sh
-git log --show-signature -1
+### 1. Install GPG
+
+- **macOS:** Install via [Homebrew](https://brew.sh/): `brew install gpg`
+- **Windows:** Install via [Gpg4win](https://www.gpg4win.org/).
+- **Linux:** Install via your package manager: `sudo apt-get install gnupg`
+
+### 2. Generate Your GPG Key
+
+Run the following command and follow the prompts. For a detailed walkthrough, see GitHub's guide on [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key).
+
+```bash
+gpg --full-generate-key
 ```
 
-Git will display signature verification if everything is set up correctly.
+**Key recommendations:**
+
+- Key type: RSA and RSA (default) is a good choice.
+- Keysize: Use 4096 bits for strong security.
+- Email address: This must match the email you use for your GitHub account.
+
+### 3. Add Your GPG Key to GitHub
+
+1. **List your keys** to find your GPG key ID:
+
+   ```bash
+   gpg --list-secret-keys --keyid-format=long
+   ```
+
+   Copy the key ID (the long string of characters after `rsa4096/`).
+
+2. **Export your public key**:
+
+   ```bash
+   gpg --armor --export YOUR_KEY_ID
+   ```
+
+3. **Add to GitHub**: Copy the entire output and paste it as a new GPG key in your GitHub settings. For step-by-step instructions, see GitHub's guide on [Adding a GPG key to your GitHub account](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
+
+### 4. Configure Git
+
+Tell Git to use your key and sign all commits automatically. For more details, see GitHub's guide on [Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
+
+```bash
+# Replace YOUR_KEY_ID with the one you copied earlier
+git config --global user.signingkey YOUR_KEY_ID
+git config --global commit.gpgsign true
+```
+
+### 5. Verify Your Setup
+
+Test that signing is working without adding unnecessary commits to your history:
+
+```bash
+# Check your Git configuration
+git config --global --get user.signingkey
+git config --global --get commit.gpgsign
+
+# Test GPG signing (this won't create a commit)
+echo "test" | gpg --clearsign
+```
+
+If GPG signing works, you should see a signed message. If you get errors, check that your GPG agent is running and your key is accessible.
 
 ---
 
-## Troubleshooting
+## Signing Unsigned Commits
 
-### Git Says "GPG Failed to Sign the Data"
+If you have commits that weren't signed, you'll need to amend or rebase them. **Warning**: These operations rewrite commit history, so coordinate with your team if working on shared branches.
 
-- Ensure `gitsign` is correctly installed and configured.
-- Run `git config --global commit.gpgsign true` again.
+### Sign the Most Recent Commit
 
-### GitHub Shows "Unverified" for My Signed Commit
+If your last commit is unsigned:
 
-This usually occurs because **GitHub does not trust Sigstore’s root certificate authority (CA)** by default. Even though your commit is correctly signed, GitHub may mark it as "Unverified."
-
-To verify your commit manually, you can use the following command:
-
-```sh
-gitsign verify \
-  --certificate-identity="<your-identity@example.com>" \
-  --certificate-oidc-issuer="https://github.com/login/oauth" \
-  HEAD
-```
-
-Replace `<your-identity@example.com>` with your actual identity.
-
-This command checks the authenticity of the commit using the Sigstore certificate.
-
-If the commit is valid, you will see a successful verification message in the terminal.
-
----
-
-## Reference Documentation
-
-For more details on keyless commit signing with Sigstore, check the official documentation:  
-[Sigstore gitsign Documentation](https://docs.sigstore.dev/cosign/signing/gitsign/)
-
----
-
-## Signing Previous Unsigned Commits
-
-If you have already made commits without signing them, you can retroactively sign those commits using Git's interactive rebase feature. Please note that this process rewrites commit history, so it is recommended only for commits that haven't been pushed to a shared repository (or if you are confident all collaborators are informed).
-
-### Steps to Sign Previous Commits
-
-1. Start an interactive rebase:
-
-```sh
-git rebase -i HEAD~N
-```
-
-Replace `N` with the number of past commits you want to sign.
-
-2. In the interactive editor, change `pick` to `edit` for each commit you want to sign.
-
-3. For each commit, run:
-
-```sh
+```bash
+# Amend the last commit with a signature
 git commit --amend --no-edit -S
 ```
 
-This command amends the commit and adds your signature.
+### Sign Multiple Recent Commits (Interactive Rebase)
 
-4. Continue the rebase:
+To sign several recent unsigned commits:
 
-```sh
+```bash
+# Start interactive rebase for the last N commits
+git rebase -i HEAD~N --exec "git commit --amend --no-edit -S"
+
+# Alternative: rebase back to a specific commit
+git rebase -i <commit-hash>^
+```
+
+In the interactive rebase editor, change `pick` to `edit` for each commit you want to sign, then for each commit:
+
+```bash
+git commit --amend --no-edit -S
 git rebase --continue
 ```
 
-Repeat the signing process for each commit marked for edit.
+### Important Notes
 
-For a full reference, see the Hyperledger Indy documentation:  
-[How to Sign Previous Commits](https://hyperledger-indy.readthedocs.io/projects/sdk/en/latest/docs/contributors/signing-commits.html#how-to-sign-previous-commits)
+- **Force push required**: After rewriting history, you'll need to force push: `git push --force-with-lease`
+- **Team coordination**: Inform team members as they'll need to reset their local branches
+- **Backup first**: Create a backup branch before rewriting history: `git branch backup-branch`
 
----
+### Troubleshooting Signing Issues
 
-## Conclusion
+**GPG Agent Not Running:**
 
-This guide is intended for contributors to this project. Please ensure your commits are signed using Gitsign to maintain the security and authenticity of the codebase. Commit signing helps us establish trust and prevent unauthorized code changes.
+```bash
+# Start GPG agent
+gpg-agent --daemon
+# Or restart it
+gpgconf --kill gpg-agent
+gpgconf --launch gpg-agent
+```
 
-If you have questions or run into issues, refer to the troubleshooting section or contact the maintainers.
+**Email Mismatch:**
+Ensure your Git email matches your GPG key email:
+
+```bash
+git config --global user.email "your-email@example.com"
+# Check your GPG key email
+gpg --list-secret-keys --keyid-format=long
+```
+
+**Key Not Found:**
+
+```bash
+# List available keys
+gpg --list-secret-keys --keyid-format=long
+# Set the correct key ID
+git config --global user.signingkey YOUR_CORRECT_KEY_ID
+```

--- a/docs/COMMIT_SIGNING_GUIDE.md
+++ b/docs/COMMIT_SIGNING_GUIDE.md
@@ -20,6 +20,8 @@ Commit signing is a process that cryptographically verifies that a commit was ma
 - Required by some security-conscious projects
 - Useful in compliance-driven workflows
 
+> **Note**: This project supports both GPG and Gitsign for commit signing. Choose the method that works best for your workflow.
+
 ---
 
 ## How to Set Up Commit Signing with Sigstore (gitsign)


### PR DESCRIPTION
## Replace Gitsign with Native GPG Signing Guide                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                              
  ### Summary                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                              
  This PR replaces the Sigstore/Gitsign commit signing documentation with a simpler, native GPG signing guide.                                                                                                                                                                
                                                                                                                                                                                                                                                                              
  ### What Changed                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                              
  - **Replaced signing method**: Removed Gitsign (keyless/Sigstore) instructions in favor of native GPG signing                                                                                                                                                               
  - **Simplified documentation**: Reduced from 285 lines to 139 lines by removing redundant commit message guidelines (already covered in CONTRIBUTING.md)                                                                                                                    
  - **Added spell check terms**: Added GPG-related terms (`keysize`, `keyid`, `signingkey`, `clearsign`, `gpgconf`) to `.cspell.json`                                                                                                                                         
                                                                                                                                                                                                                                                                              
  ### Why                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                              
  - GPG signing is more widely supported and doesn't require external dependencies like Sigstore                                                                                                                                                                              
  - Commit message guidelines were duplicated — CONTRIBUTING.md already covers this                                                                                                                                                                                           
  - Simpler setup process for contributors                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                              
  ### Checklist                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  - [x] Code compiles without errors                                                                                                                                                                                                                                          
  - [x] Linted (using project's linting tool)                                                                                                                                                                                                                                 
  - [x] Documentation updated                                                                                                                                                                                                                                                 
  - [x] Self-reviewed for obvious issues                                                                                                                                                                                                                                      
  - [x] No sensitive data exposed                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                              
  ### Related Issues                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
  N/A         