### PR TITLE
fix(hooks): whitelist bots for CI pushes to protected branches

### DIFF
--- a/scripts/check-branch.sh
+++ b/scripts/check-branch.sh
@@ -11,6 +11,15 @@
 
 . "$(dirname "$0")/utils.sh"
 
+# Whitelist bots in CI environments (allows semantic-release to push)
+if [ "$CI" = "true" ]; then
+  ALLOWED_BOTS="github-actions[bot] dependabot[bot] semantic-release-bot"
+  if echo "$ALLOWED_BOTS" | grep -qw "$GITHUB_ACTOR"; then
+    log_success "Branch check skipped for bot: $GITHUB_ACTOR"
+    exit 0
+  fi
+fi
+
 PROTECTED_BRANCHES="main master pre-main"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  This PR fixes the CI workflow failure caused by git hooks blocking semantic-release bot from pushing version bump commits to protected branches.                                                                                                                           
   
  ### What was changed and why                                                                                                                                                                                                                                               
                  
  **Problem:**
  - When semantic-release tries to push version bump commits to `pre-main`, the `check-branch.sh` hook blocks it because `pre-main` is a protected branch
  - This caused the "Release Beta & Deploy QA" workflow to fail

  **Solution:**
  - Updated `scripts/check-branch.sh` to detect CI environment and whitelist known bots
  - Whitelisted bots: `github-actions[bot]`, `dependabot[bot]`, `semantic-release-bot`
  - The hook now skips branch protection check when a whitelisted bot is pushing in CI