### PR TITLE
fix(ci): disable husky hooks in semantic-release step

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -50,6 +50,7 @@ jobs:
             conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          HUSKY: 0
 
       - name: Beta Release Info
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
             conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          HUSKY: 0
 
       - name: Release Info
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/scripts/check-branch.sh
+++ b/scripts/check-branch.sh
@@ -11,15 +11,6 @@
 
 . "$(dirname "$0")/utils.sh"
 
-# Whitelist bots in CI environments (allows semantic-release to push)
-if [ "$CI" = "true" ]; then
-  ALLOWED_BOTS="github-actions[bot] dependabot[bot] semantic-release-bot"
-  if echo "$ALLOWED_BOTS" | grep -qw "$GITHUB_ACTOR"; then
-    log_success "Branch check skipped for bot: $GITHUB_ACTOR"
-    exit 0
-  fi
-fi
-
 PROTECTED_BRANCHES="main master pre-main"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  This PR fixes the CI workflow failure caused by git hooks blocking semantic-release from committing version bumps to protected branches.                                                                                                                                   
                                                                                                                                                                                                                                                                             
  ### What was changed and why                                                                                                                                                                                                                                               
                  
  **Problem:**
  - When semantic-release creates a version bump commit on `pre-main`, the `check-branch.sh` hook in husky blocks it because `pre-main` is a protected branch
  - This caused the "Release Beta & Deploy QA" workflow to fail with error: `You are on a protected branch: 'pre-main'`

  **Solution:**
  - Added `HUSKY=0` environment variable to semantic-release steps in both workflows
  - This disables husky hooks during CI, allowing semantic-release to commit and push freely
  - Local development still has all hooks enforced
