### PR TITLE
fix(config): ignore CHANGELOG.md in Prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 build
 coverage
+CHANGELOG.md


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  This PR fixes the deploy-qa workflow failure caused by Prettier formatting check failing on the auto-generated CHANGELOG.md file.                                                                                                                                          
                                                                                                                                                                                                                                                                             
  ### What was changed and why                                                                                                                                                                                                                                               
                  
  **Problem:**
  - Semantic-release generates `CHANGELOG.md` automatically during the release process
  - The generated file doesn't follow Prettier formatting
  - `npm run verify` fails with: `Code style issues found in CHANGELOG.md`
  - This blocks the deploy-qa job from completing

  **Solution:**
  - Added `CHANGELOG.md` to `.prettierignore`
  - Auto-generated files shouldn't be subject to formatting checks