### PR TITLE
chore(config): exclude CHANGELOG.md from spell check

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -73,7 +73,15 @@
     "สวัสดี",
     "ฉันคือ"
   ],
-  "ignorePaths": ["node_modules", "coverage", "dist", ".git", ".husky/_", "package-lock.json"],
+  "ignorePaths": [
+    "node_modules",
+    "coverage",
+    "dist",
+    ".git",
+    ".husky/_",
+    "package-lock.json",
+    "CHANGELOG.md"
+  ],
   "enableFiletypes": ["js", "jsx", "ts", "tsx", "json", "md", "css", "html"],
   "allowCompoundWords": false,
   "reporters": ["default"],


### PR DESCRIPTION
                                                                                                                              
  ## Description  

  ### What was changed and why

  Added `CHANGELOG.md` to the `ignorePaths` array in `.cspell.json` to prevent spell check errors on auto-generated changelog content (e.g., "flexbox").

