### PR TITLE
Feat/profile component

### DIFF
--- a/src/pages/PortfolioPage.jsx
+++ b/src/pages/PortfolioPage.jsx
@@ -63,7 +63,7 @@ export function PortfolioPage({ profile }) {
   const customSections = (profile.customSections ?? []).filter(s => s.visible);
 
   return (
-    <div className="mx-auto max-w-4xl pl-[7.5%] pr-[9.2%] sm:px-12 md:px-20">
+    <div className="mx-auto max-w-4xl pl-[52px] pr-4 sm:px-12 md:px-20">
       <SocialsSidebar socials={profile.contact?.socials ?? []} />
       <SectionNav profile={profile} />
       <Hero basics={profile.basics} contact={profile.contact} />

--- a/src/sections/SectionNav/index.jsx
+++ b/src/sections/SectionNav/index.jsx
@@ -1,9 +1,11 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@/components/ui/icons';
 import { getSectionIcon } from '@/components/ui/icons/sectionIcons';
+import { Tooltip } from '@/components/ui/Tooltip';
 import PropTypes from 'prop-types';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const PER_PAGE = 5;
+const LONG_PRESS_DURATION = 500;
 
 /**
  * Right sidebar — section navigation with icons.
@@ -18,6 +20,9 @@ export function SectionNav({ profile }) {
   const [offset, setOffset] = useState(0);
   const [activeId, setActiveId] = useState('hero');
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [activeTooltip, setActiveTooltip] = useState(null);
+  const longPressTimer = useRef(null);
+  const isLongPress = useRef(false);
 
   const SECTION_LABELS = useMemo(
     () =>
@@ -107,6 +112,7 @@ export function SectionNav({ profile }) {
     function handleClickOutside(e) {
       if (!e.target.closest('[data-section-nav]')) {
         setMobileMenuOpen(false);
+        setActiveTooltip(null);
       }
     }
 
@@ -114,9 +120,19 @@ export function SectionNav({ profile }) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [mobileMenuOpen]);
 
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
+  }, []);
+
   if (sections.length === 0) return null;
 
   const activeIdx = sections.findIndex(s => s.id === activeId);
+  const activeSection = sections.find(s => s.id === activeId);
   const hasPrev = activeIdx > 0;
   const hasNext = activeIdx < sections.length - 1;
   const visible = sections.slice(offset, offset + PER_PAGE);
@@ -128,34 +144,69 @@ export function SectionNav({ profile }) {
    * @param {string} id - The section element id
    */
   function scrollTo(id) {
+    if (isLongPress.current) {
+      isLongPress.current = false;
+      return;
+    }
     document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
     setMobileMenuOpen(false);
+    setActiveTooltip(null);
+  }
+
+  /**
+   * Starts long press timer for showing tooltip.
+   *
+   * @param {string} id - The section id
+   */
+  function handleTouchStart(id) {
+    isLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      isLongPress.current = true;
+      setActiveTooltip(id);
+    }, LONG_PRESS_DURATION);
+  }
+
+  /**
+   * Clears long press timer.
+   */
+  function handleTouchEnd() {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+    }
   }
 
   return (
     <>
       {/* Mobile: Single button with dropdown */}
       <div className="fixed right-2 top-14 z-30 md:hidden" data-section-nav>
-        <button
-          aria-label="Navigate sections"
-          className="flex size-8 items-center justify-center rounded-full bg-[var(--color-primary)] text-white shadow-lg transition-transform hover:scale-105"
-          onClick={() => setMobileMenuOpen(o => !o)}
-        >
-          <ActiveIcon className="size-4" />
-        </button>
+        <Tooltip content={activeSection?.label || 'Navigate'} position="left">
+          <button
+            aria-label="Navigate sections"
+            className="flex size-8 items-center justify-center rounded-full bg-[var(--color-primary)] text-white shadow-lg transition-transform hover:scale-105"
+            onClick={() => setMobileMenuOpen(o => !o)}
+          >
+            <ActiveIcon className="size-4" />
+          </button>
+        </Tooltip>
 
         {mobileMenuOpen && (
-          <div className="absolute right-0 mt-2 flex flex-col gap-1.5 rounded-xl bg-[var(--color-bg)] p-2 shadow-xl">
+          <div
+            className="absolute -right-1.5 mt-2 flex flex-col items-center gap-2 rounded-xl px-1.5 py-2"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-text) 5%, transparent)' }}
+          >
             {sections.map(section => {
               const Icon = getSectionIcon(section.id);
               const isActive = section.id === activeId;
+              const isTooltipVisible = activeTooltip === section.id;
               return (
                 <button
-                  className={`flex size-8 items-center justify-center rounded-lg transition-all ${
+                  className={`relative flex size-8 items-center justify-center rounded-lg transition-all ${
                     isActive ? 'text-[var(--color-primary)]' : 'opacity-50 hover:opacity-100'
                   }`}
                   key={section.id}
                   onClick={() => scrollTo(section.id)}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchStart={() => handleTouchStart(section.id)}
                   style={
                     isActive
                       ? {
@@ -166,6 +217,11 @@ export function SectionNav({ profile }) {
                   }
                 >
                   <Icon className="size-4" />
+                  <span
+                    className={`pointer-events-none absolute right-full mr-3 whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] transition-opacity ${isTooltipVisible ? 'opacity-100' : 'opacity-0'}`}
+                  >
+                    {section.label}
+                  </span>
                 </button>
               );
             })}

--- a/src/sections/SocialsSidebar/index.jsx
+++ b/src/sections/SocialsSidebar/index.jsx
@@ -1,12 +1,14 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@/components/ui/icons';
 import { getSocialIcon } from '@/components/ui/icons/socialIcons';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const PER_PAGE = 5;
+const LONG_PRESS_DURATION = 500;
 
 /**
  * Left sidebar — social media icon links, paginated with arrows.
+ * On mobile: tap navigates, long press shows tooltip.
  *
  * @param {object} props - Component props
  * @param {Array} props.socials - Array of social link objects ({ label, url })
@@ -14,41 +16,121 @@ const PER_PAGE = 5;
  */
 export function SocialsSidebar({ socials }) {
   const [offset, setOffset] = useState(0);
+  const [activeTooltip, setActiveTooltip] = useState(null);
+  const longPressTimer = useRef(null);
+  const isLongPress = useRef(false);
+
+  // Close tooltip when clicking outside
+  useEffect(() => {
+    if (!activeTooltip) return;
+
+    /**
+     * Closes tooltip when clicking outside.
+     *
+     * @param {MouseEvent} e - The mouse event
+     */
+    function handleClickOutside(e) {
+      if (!e.target.closest('[data-social-sidebar]')) {
+        setActiveTooltip(null);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [activeTooltip]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
+  }, []);
 
   if (!socials || socials.length === 0) return null;
 
+  const needsPagination = socials.length > PER_PAGE;
   const canUp = offset > 0;
   const canDown = offset + PER_PAGE < socials.length;
   const visible = socials.slice(offset, offset + PER_PAGE);
 
+  /**
+   * Starts long press timer for showing tooltip.
+   *
+   * @param {string} label - The social label
+   */
+  function handleTouchStart(label) {
+    isLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      isLongPress.current = true;
+      setActiveTooltip(label);
+    }, LONG_PRESS_DURATION);
+  }
+
+  /**
+   * Clears long press timer.
+   */
+  function handleTouchEnd() {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+    }
+  }
+
+  /**
+   * Prevents navigation if long press was triggered.
+   *
+   * @param {Event} e - The click event
+   */
+  function handleClick(e) {
+    if (isLongPress.current) {
+      e.preventDefault();
+      isLongPress.current = false;
+    }
+  }
+
   return (
     <div
-      className="fixed left-0.5 top-1/2 z-30 flex -translate-y-1/2 flex-col items-center gap-1 rounded-lg px-0.5 py-1 md:left-5 md:gap-3 md:rounded-2xl md:px-2.5 md:py-3 md:backdrop-blur-sm"
+      className="fixed left-1 top-1/2 z-30 flex -translate-y-1/2 flex-col items-center gap-2 rounded-xl px-1.5 py-2 md:left-5 md:gap-3 md:rounded-2xl md:px-2.5 md:py-3 md:backdrop-blur-sm"
+      data-social-sidebar
       style={{ backgroundColor: 'color-mix(in srgb, var(--color-text) 5%, transparent)' }}
     >
-      <button
-        className={`group relative text-[var(--color-primary)] transition-all ${canUp ? 'opacity-60 hover:opacity-100' : 'pointer-events-none opacity-0'}`}
-        onClick={() => setOffset(o => Math.max(0, o - 1))}
-        tabIndex={canUp ? 0 : -1}
-      >
-        <ChevronUpIcon className="size-2.5 md:size-4" />
-        <span className="pointer-events-none absolute left-full ml-3 hidden whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] opacity-0 transition-opacity group-hover:opacity-100 md:block">
-          More
-        </span>
-      </button>
+      {needsPagination && (
+        <button
+          className={`group relative text-[var(--color-primary)] transition-all ${canUp ? 'opacity-60 hover:opacity-100' : 'pointer-events-none opacity-0'}`}
+          onClick={() => setOffset(o => Math.max(0, o - 1))}
+          tabIndex={canUp ? 0 : -1}
+        >
+          <ChevronUpIcon className="size-4 md:size-4" />
+          <span className="pointer-events-none absolute left-full ml-3 hidden whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] opacity-0 transition-opacity group-hover:opacity-100 md:block">
+            More
+          </span>
+        </button>
+      )}
 
-      <div className="flex flex-col gap-1 md:gap-3">
+      <div className="flex flex-col gap-2 md:gap-3">
         {visible.map(social => {
           const Icon = getSocialIcon(social.label);
+          const isTooltipVisible = activeTooltip === social.label;
           return (
             <a
-              className="group relative flex size-5 items-center justify-center rounded text-[var(--color-text)] opacity-60 transition-all hover:text-[var(--color-primary)] hover:opacity-100 md:size-10 md:rounded-xl"
+              className="group relative flex size-8 items-center justify-center rounded-lg text-[var(--color-text)] opacity-60 transition-all hover:text-[var(--color-primary)] hover:opacity-100 md:size-10 md:rounded-xl"
               href={social.url}
               key={social.label}
+              onClick={handleClick}
+              onTouchEnd={handleTouchEnd}
+              onTouchStart={() => handleTouchStart(social.label)}
               rel="noopener noreferrer"
               target="_blank"
             >
-              <Icon className="size-3.5 md:size-5" />
+              <Icon className="size-5 md:size-5" />
+              {/* Mobile tooltip */}
+              <span
+                className={`pointer-events-none absolute left-full ml-3 whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] transition-opacity md:hidden ${isTooltipVisible ? 'opacity-100' : 'opacity-0'}`}
+              >
+                {social.label}
+              </span>
+              {/* Desktop tooltip */}
               <span className="pointer-events-none absolute left-full ml-3 hidden whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] opacity-0 transition-opacity group-hover:opacity-100 md:block">
                 {social.label}
               </span>
@@ -57,16 +139,18 @@ export function SocialsSidebar({ socials }) {
         })}
       </div>
 
-      <button
-        className={`group relative text-[var(--color-primary)] transition-all ${canDown ? 'opacity-60 hover:opacity-100' : 'pointer-events-none opacity-0'}`}
-        onClick={() => setOffset(o => Math.min(socials.length - PER_PAGE, o + 1))}
-        tabIndex={canDown ? 0 : -1}
-      >
-        <ChevronDownIcon className="size-2.5 md:size-4" />
-        <span className="pointer-events-none absolute left-full ml-3 hidden whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] opacity-0 transition-opacity group-hover:opacity-100 md:block">
-          More
-        </span>
-      </button>
+      {needsPagination && (
+        <button
+          className={`group relative text-[var(--color-primary)] transition-all ${canDown ? 'opacity-60 hover:opacity-100' : 'pointer-events-none opacity-0'}`}
+          onClick={() => setOffset(o => Math.min(socials.length - PER_PAGE, o + 1))}
+          tabIndex={canDown ? 0 : -1}
+        >
+          <ChevronDownIcon className="size-4 md:size-4" />
+          <span className="pointer-events-none absolute left-full ml-3 hidden whitespace-nowrap rounded-lg bg-[var(--color-text)] px-2.5 py-1 text-xs text-[var(--color-bg)] opacity-0 transition-opacity group-hover:opacity-100 md:block">
+            More
+          </span>
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
  ## Description
                                                                                                                                    
  ### What was changed and why

  This PR improves the mobile experience for the social sidebar and section navigation:

  **SocialsSidebar:**
  - Increased mobile icon sizes for better touch targets (`size-5` → `size-8`)
  - Added long-press (500ms) to show tooltip, tap to navigate
  - Pagination arrows only render when needed (> 5 items)
  - Improved spacing and positioning

  **SectionNav:**
  - Added long-press (500ms) tooltips for dropdown section icons
  - Added tooltip on floating button showing current section name
  - Tap navigates, long-press shows label

  **PortfolioPage:**
  - Adjusted mobile padding (`pl-[52px] pr-4`) to accommodate floating sidebars

  ### Limitations
  - None
